### PR TITLE
Corrections dg1000z

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ __pycache__/
 .project
 .pydevproject
 .DS_Store
+
+# private VSCode settings
+.vscode

--- a/sds1004x_bode/awgdrivers/dg800.py
+++ b/sds1004x_bode/awgdrivers/dg800.py
@@ -169,8 +169,11 @@ class RigolDG800(BaseAWG):
             self.set_amplitude(1, amplitude)
             self.set_amplitude(2, amplitude)
         else:
-            # Adjust the amplitude to the defined load impedance
-            amplitude = amplitude / self.v_out_coeff[channel - 1]
+            # For Rigols it is not necessary to adjust the amplitude to the defined load impedance
+            # amplitude = amplitude / self.v_out_coeff[channel - 1]
+            # SDS1000X HD sends always the voltage as VPP, even if set to VRMS in the Bode plot setup of the scope
+            # Rigols interpret the amplitude to have the unit that was used by the last manual entry or the last UNIT command
+            self._send_command(f":SOURCE{channel}:VOLT:UNIT VPP") 
             self._send_command(f":SOURCE{channel}:VOLT:AMPL {amplitude:.3f}")
 
     def set_offset(self, channel: int, offset: float):


### PR DESCRIPTION
Hi bateau020,

while testing I noticed that the siggen used wrong voltages for the test
signal. I traced it down and I could see that the scope always sends the
voltage values in Vpp even if the voltage unit is set to Vrms in the Bode plot
setup in the scope.

Since the Rigols use by default the voltage unit that was used the last time a
value was entered manually this could be wrong and the voltage unit should be
set explicitly.

The Rigol signal generators have a separate SCPI command for setting the unit
in which the voltages are provided (i.e. VPP, VRMS, DBM). I added this to set
VPP before the voltage value is set. I tested on my DG1062Z, but the DG800/900
behave the same according to their programming manuals.

Furthermore there is no need to calculate the actual output voltage of the
generator depending on the output load. This is done automatically by the
siggen itself when setting the "impedance". The siggen has a fixed output
impedance of 50 Ohm. The "impedance setting" tells the siggen how to interpret
the output voltage setting with regard to its 50Ohm impedance.

So I removed these lines. My tests show that now all voltages used for the
bode plot generation are now correct with my Rigol siggen.
